### PR TITLE
out of bounds error in forced null-termination

### DIFF
--- a/lib/lime_writer.c
+++ b/lib/lime_writer.c
@@ -296,7 +296,7 @@ int write_lime_record_binary_header(FILE *fp, LimeRecordHeader *h)
   strncpy((char*)lime_hdr_rec_type,h->type,MAX_LIME_HDR_REC_TYPE);
 
   /* Force a null termination */
-  lime_hdr_rec_type[MAX_LIME_HDR_REC_TYPE] = '\0';
+  lime_hdr_rec_type[MAX_LIME_HDR_REC_TYPE-1] = '\0';
 
   
 #ifdef JCO_DEBUG


### PR DESCRIPTION
Had some really weird crashes on machines with very new GCCs, turns out this was the cause. (results in a stack smashing error)