### PR TITLE
Eliminated compile warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(C-Lime VERSION 2.53 LANGUAGES C)
 #Boiler Plate for installation
 include(GNUInstallDirs)
 include(CheckIncludeFile)
-include(CheckSymbolExists)
+include(CheckFunctionExists)
 include(CheckTypeSize)
 #Boiler Plate for Testing
 include(CTest)
@@ -24,7 +24,7 @@ endif()
 option(LIME_ENABLE_SANITIZERS "Enable Address and Undefined Behaviour Sanitizers" OFF)
 
 
-check_symbol_exists("fseeko" "stdio.h" HAVE_FSEEKO)
+check_function_exists("fseeko" HAVE_FSEEKO)
 check_include_file("stdint.h" HAVE_STDINT_H)
 check_include_file("memory.h" HAVE_MEMORY_H)
 check_include_file("inttypes.h" HAVE_INTTYPES_H)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,8 +10,6 @@ include(CheckTypeSize)
 include(CTest)
 
 #Options
-option(LIME_LARGEGFILE "Enable Large File Support" OFF)
-
 ### FIXME: Do we still need this?
 option(LIME_DCAP "Ebable DCache DCap Support" OFF)
 if( LIME_DCAP )

--- a/examples/lime_pack.c
+++ b/examples/lime_pack.c
@@ -54,18 +54,16 @@ typedef struct {
 
 
 /* Discover how many bytes there are in the file */
-n_uint64_t file_size(FILE *fp)
+int  file_size(FILE *fp, n_uint64_t* length)
 {
   n_uint64_t oldpos = ftello(fp);
-  n_uint64_t length;
   
   if (DCAPL(fseeko)(fp, 0L,SEEK_END) == -1)
     return -1;
   
-  length = DCAPL(ftello)(fp);
+  *length = DCAPL(ftello)(fp);
   
-  return ( DCAPL(fseeko)(fp,oldpos,SEEK_SET) == -1 ) ? -1 : length;
-  
+  return DCAPL(fseeko)(fp,oldpos,SEEK_SET);
 }
 
 void read_list_line(List_Line *list, FILE *fp_list)
@@ -227,11 +225,11 @@ int main(int argc, char *argv[])
 	      fprintf(stderr, "Unable to open %s\n",curr.filename);
 	      break;
 	    }
-	  else
-	    if ((bytes = file_size(fp_src)) == -1)
+	  else {
+	    if ( file_size(fp_src,&bytes) == -1)
 	      fprintf(stderr,"Can't compute length of file %s\n", 
 		      curr.filename);
-
+          }
 	  /* Reset stream pointer to beginning of file */
 	  fseeko(fp_src,0L,SEEK_SET);
 	  
@@ -240,8 +238,8 @@ int main(int argc, char *argv[])
 	  if ( next.ss_count <= 0 || next.eof ) ME_flag = 1;
 	    
 	  /* Announce file */
-	  printf("%2d %3d %8ld %s\n\t\t%s\n",
-		 msg, rec, (long int)bytes, curr.lime_type, curr.filename);
+	  printf("%2d %3d %8lu %s\n\t\t%s\n",
+		 msg, rec, bytes, curr.lime_type, curr.filename);
 
 	  /* Write header */
 	  status = write_hdr(bytes,curr.lime_type,MB_flag,ME_flag,dg);

--- a/examples/lime_unpack.c
+++ b/examples/lime_unpack.c
@@ -20,7 +20,9 @@
 #include <string.h>
 #include <stdlib.h>
 #define MAXFILENAME 512
-#define MAXDIRNAME 512
+
+/* Allow dirname extnesion with filetypes etc up t 32 characters */
+#define MAXDIRNAME 480
 #define MAXCOMLINE 512
 #define MAXBUF 1048576
 
@@ -73,7 +75,7 @@ int main(int argc, char *argv[])
     fprintf(stderr,"Not enough room for directory name\n");
     return EXIT_FAILURE;
   }
-  snprintf(dirname,MAXDIRNAME,"%s.contents",limefile);
+  snprintf(dirname,MAXDIRNAME-strlen(".contents"),"%s.contents",limefile);
 
   if(strlen(dirname) + strlen("mkdir -p ") > MAXCOMLINE - 1){
     fprintf(stderr,"Not enough room for command line\n");

--- a/examples/lime_writer_test1.c
+++ b/examples/lime_writer_test1.c
@@ -104,7 +104,8 @@ int write_rec(LimeWriter *writer, int MB_flag, int ME_flag, int shuffle,
 
 int main(int argc, char *argv[]) 
 {
-
+  _LIME_UNUSED_PARAM(argc);
+  _LIME_UNUSED_PARAM(argv);
   char lime_file[] = "lime_file_test";
 
   LimeWriter *writer;

--- a/include/lime.h
+++ b/include/lime.h
@@ -7,4 +7,9 @@
 #include <lime_header.h>
 #include <lime_writer.h>
 #include <lime_reader.h>
+
+/* Handy macro to mark parameters unused to silence errors */
+#ifndef _LIME_UNUSED_PARAM
+#define _LIME_UNUSED_PARAM(p)  (void)(p)
+#endif 
 #endif

--- a/include/lime_fseeko.h
+++ b/include/lime_fseeko.h
@@ -3,19 +3,16 @@
 
 #include "lime_config.h"
 
-#ifndef HAVE_FSEEKO
+#include <stdio.h>
 
+#ifndef HAVE_FSEEKO
 /* If fseeko, ftell is not defined then define our own versions of it
    which just call fseek and ftell but keep the same interface */
-#include <stdio.h>
 #include <stdlib.h>
 #include <sys/types.h>
 
 int fseeko(FILE *stream, off_t offset, int whence);
 off_t ftello(FILE *stream);
-
-#else
-#include <stdio.h>
 #endif
 
 #endif

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -14,6 +14,11 @@ target_include_directories(lime PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
   $<INSTALL_INTERFACE:include>)
 
+target_compile_definitions(lime PUBLIC _LARGEFILE_SOURCE _FILE_OFFSET_BITS=64 )
+set_target_properties(lime PROPERTIES
+	                C_STANDARD 99
+			C_EXTENSIONS OFF)
+
 # generated includes
 target_include_directories(lime PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/../include>


### PR DESCRIPTION
I went through this and fixed all compiler warnings from GCC with -Wall -Wextra
Main fixes were:

i) enable _LARGEFILE_SOURCE  and _FILE_OFFSET_BITS=64 
(this gets rid of ftello/fseeko related issues)

ii) When seeking there were narrowing conversions from unsigned to signed numbers. E.g. comparing an int64 and uint64. I fixed these by making the new_record_ptr to be in64, and separating out -ve offsets in the seek.

As of now my simple tests from the examples directory seem to pass OK. 
